### PR TITLE
fix freertos submodule link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "third-party/ceedling"]
 	path = third-party/ceedling
 	url = https://github.com/ThrowTheSwitch/Ceedling.git
+[submodule "third-party/freertos/freertos_kernel"]
+	path = third-party/freertos/freertos_kernel
+	url = https://github.com/FreeRTOS/FreeRTOS-Kernel.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "third-party/ceedling"]
 	path = third-party/ceedling
 	url = https://github.com/ThrowTheSwitch/Ceedling.git
-[submodule "third-party/freertos"]
-	path = third-party/freertos
-	url = https://github.com/aws/amazon-freertos.git

--- a/demo/cross/shared/build/arm-cortex/freertos/ciaa-nxp/mcuxpresso/.cproject
+++ b/demo/cross/shared/build/arm-cortex/freertos/ciaa-nxp/mcuxpresso/.cproject
@@ -21,11 +21,11 @@
 							<targetPlatform binaryParser="org.eclipse.cdt.core.ELF;org.eclipse.cdt.core.GNU_ELF" id="com.crt.advproject.platform.exe.debug.713919036" name="ARM-based MCU (Debug)" superClass="com.crt.advproject.platform.exe.debug"/>
 							<builder buildPath="${workspace_loc:/freertos_blinky}/Debug" id="com.crt.advproject.builder.exe.debug.1661499681" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="Gnu Make Builder" superClass="com.crt.advproject.builder.exe.debug"/>
 							<tool id="com.crt.advproject.cpp.exe.debug.404336417" name="MCU C++ Compiler" superClass="com.crt.advproject.cpp.exe.debug">
-								<option id="com.crt.advproject.cpp.hdrlib.602149094" name="Library headers" superClass="com.crt.advproject.cpp.hdrlib"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.compiler.option.preprocessor.def.1356466611" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" valueType="definedSymbols">
+								<option id="com.crt.advproject.cpp.hdrlib.602149094" name="Library headers" superClass="com.crt.advproject.cpp.hdrlib" useByScannerDiscovery="false"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.compiler.option.preprocessor.def.1356466611" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="__MULTICORE_NONE"/>
 								</option>
-								<option id="com.crt.advproject.cpp.fpu.1445695054" name="Floating point" superClass="com.crt.advproject.cpp.fpu"/>
+								<option id="com.crt.advproject.cpp.fpu.1445695054" name="Floating point" superClass="com.crt.advproject.cpp.fpu" useByScannerDiscovery="true"/>
 							</tool>
 							<tool id="com.crt.advproject.gcc.exe.debug.1075904068" name="MCU C Compiler" superClass="com.crt.advproject.gcc.exe.debug">
 								<option id="com.crt.advproject.gcc.arch.1443062043" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="true" value="com.crt.advproject.gcc.target.cm4" valueType="enumerated"/>
@@ -144,8 +144,8 @@
 							<targetPlatform binaryParser="org.eclipse.cdt.core.ELF;org.eclipse.cdt.core.GNU_ELF" id="com.crt.advproject.platform.exe.release.139703314" name="ARM-based MCU (Release)" superClass="com.crt.advproject.platform.exe.release"/>
 							<builder buildPath="${workspace_loc:/freertos_blinky}/Release" id="com.crt.advproject.builder.exe.release.920862545" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="Gnu Make Builder" superClass="com.crt.advproject.builder.exe.release"/>
 							<tool id="com.crt.advproject.cpp.exe.release.295031157" name="MCU C++ Compiler" superClass="com.crt.advproject.cpp.exe.release">
-								<option id="com.crt.advproject.cpp.hdrlib.1742547333" name="Library headers" superClass="com.crt.advproject.cpp.hdrlib"/>
-								<option id="gnu.cpp.compiler.option.preprocessor.def.588491956" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def"/>
+								<option id="com.crt.advproject.cpp.hdrlib.1742547333" name="Library headers" superClass="com.crt.advproject.cpp.hdrlib" useByScannerDiscovery="false"/>
+								<option id="gnu.cpp.compiler.option.preprocessor.def.588491956" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false"/>
 							</tool>
 							<tool id="com.crt.advproject.gcc.exe.release.172423723" name="MCU C Compiler" superClass="com.crt.advproject.gcc.exe.release">
 								<option id="com.crt.advproject.gcc.arch.1401546833" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="true" value="com.crt.advproject.gcc.target.cm4" valueType="enumerated"/>
@@ -259,11 +259,11 @@
 							<targetPlatform binaryParser="org.eclipse.cdt.core.ELF;org.eclipse.cdt.core.GNU_ELF" id="com.crt.advproject.platform.exe.debug.1142759635" name="ARM-based MCU (Debug)" superClass="com.crt.advproject.platform.exe.debug"/>
 							<builder buildPath="${workspace_loc:/freertos_blinky}/Debug" id="com.crt.advproject.builder.exe.debug.1186540996" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="Gnu Make Builder" superClass="com.crt.advproject.builder.exe.debug"/>
 							<tool id="com.crt.advproject.cpp.exe.debug.1209540158" name="MCU C++ Compiler" superClass="com.crt.advproject.cpp.exe.debug">
-								<option id="com.crt.advproject.cpp.hdrlib.1707946987" name="Library headers" superClass="com.crt.advproject.cpp.hdrlib"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.compiler.option.preprocessor.def.862856791" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" valueType="definedSymbols">
+								<option id="com.crt.advproject.cpp.hdrlib.1707946987" name="Library headers" superClass="com.crt.advproject.cpp.hdrlib" useByScannerDiscovery="false"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.compiler.option.preprocessor.def.862856791" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="__MULTICORE_NONE"/>
 								</option>
-								<option id="com.crt.advproject.cpp.fpu.1127597253" name="Floating point" superClass="com.crt.advproject.cpp.fpu"/>
+								<option id="com.crt.advproject.cpp.fpu.1127597253" name="Floating point" superClass="com.crt.advproject.cpp.fpu" useByScannerDiscovery="true"/>
 							</tool>
 							<tool id="com.crt.advproject.gcc.exe.debug.685672284" name="MCU C Compiler" superClass="com.crt.advproject.gcc.exe.debug">
 								<option id="com.crt.advproject.gcc.arch.2097977124" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="true" value="com.crt.advproject.gcc.target.cm4" valueType="enumerated"/>
@@ -383,11 +383,11 @@
 							<targetPlatform binaryParser="org.eclipse.cdt.core.ELF;org.eclipse.cdt.core.GNU_ELF" id="com.crt.advproject.platform.exe.debug.1169515117" name="ARM-based MCU (Debug)" superClass="com.crt.advproject.platform.exe.debug"/>
 							<builder buildPath="${workspace_loc:/freertos_blinky}/Debug" id="com.crt.advproject.builder.exe.debug.1047235279" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="Gnu Make Builder" superClass="com.crt.advproject.builder.exe.debug"/>
 							<tool id="com.crt.advproject.cpp.exe.debug.1943356990" name="MCU C++ Compiler" superClass="com.crt.advproject.cpp.exe.debug">
-								<option id="com.crt.advproject.cpp.hdrlib.477741548" name="Library headers" superClass="com.crt.advproject.cpp.hdrlib"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.compiler.option.preprocessor.def.573845843" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" valueType="definedSymbols">
+								<option id="com.crt.advproject.cpp.hdrlib.477741548" name="Library headers" superClass="com.crt.advproject.cpp.hdrlib" useByScannerDiscovery="false"/>
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.compiler.option.preprocessor.def.573845843" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="__MULTICORE_NONE"/>
 								</option>
-								<option id="com.crt.advproject.cpp.fpu.2101225551" name="Floating point" superClass="com.crt.advproject.cpp.fpu"/>
+								<option id="com.crt.advproject.cpp.fpu.2101225551" name="Floating point" superClass="com.crt.advproject.cpp.fpu" useByScannerDiscovery="true"/>
 							</tool>
 							<tool id="com.crt.advproject.gcc.exe.debug.1500562922" name="MCU C Compiler" superClass="com.crt.advproject.gcc.exe.debug">
 								<option id="com.crt.advproject.gcc.arch.722837971" name="Architecture" superClass="com.crt.advproject.gcc.arch" useByScannerDiscovery="true" value="com.crt.advproject.gcc.target.cm4" valueType="enumerated"/>
@@ -528,15 +528,18 @@
 &lt;/TargetConfig&gt;</projectStorage>
 	</storageModule>
 	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Debug_CIAA-NXP"/>
 		<configuration configurationName="Debug_with_Semihosting">
+			<resource resourceType="PROJECT" workspacePath="/freertos_shared"/>
+		</configuration>
+		<configuration configurationName="Debug_EDU-CIAA-NXP"/>
+		<configuration configurationName="Release">
 			<resource resourceType="PROJECT" workspacePath="/freertos_shared"/>
 		</configuration>
 		<configuration configurationName="Debug">
 			<resource resourceType="PROJECT" workspacePath="/freertos_shared"/>
 		</configuration>
-		<configuration configurationName="Release">
-			<resource resourceType="PROJECT" workspacePath="/freertos_shared"/>
-		</configuration>
+		<configuration configurationName="Legacy_Debug"/>
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
 	<storageModule moduleId="com.crt.advproject"/>

--- a/demo/cross/shared/build/arm-cortex/freertos/ciaa-nxp/mcuxpresso/.settings/org.eclipse.cdt.core.prefs
+++ b/demo/cross/shared/build/arm-cortex/freertos/ciaa-nxp/mcuxpresso/.settings/org.eclipse.cdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+environment/project/com.crt.advproject.config.exe.debug.1324172874.2082812930.1155101958/BOARD/delimiter=;
+environment/project/com.crt.advproject.config.exe.debug.1324172874.2082812930.1155101958/BOARD/operation=append
+environment/project/com.crt.advproject.config.exe.debug.1324172874.2082812930.1155101958/BOARD/value=edu_ciaa_nxp
+environment/project/com.crt.advproject.config.exe.debug.1324172874.2082812930.1155101958/append=true
+environment/project/com.crt.advproject.config.exe.debug.1324172874.2082812930.1155101958/appendContributed=true
+environment/project/com.crt.advproject.config.exe.debug.1324172874.2082812930/BOARD/delimiter=;
+environment/project/com.crt.advproject.config.exe.debug.1324172874.2082812930/BOARD/operation=append
+environment/project/com.crt.advproject.config.exe.debug.1324172874.2082812930/BOARD/value=ciaa_nxp
+environment/project/com.crt.advproject.config.exe.debug.1324172874.2082812930/append=true
+environment/project/com.crt.advproject.config.exe.debug.1324172874.2082812930/appendContributed=true

--- a/demo/libbsp/platform/arm-cortex/arm_cm4f/ciaa-nxp/bsp_shared.c
+++ b/demo/libbsp/platform/arm-cortex/arm_cm4f/ciaa-nxp/bsp_shared.c
@@ -356,15 +356,6 @@ rkh_trc_close( void )
 	SERIAL_TRACE_CLOSE();
 }
 
-void
-bsp_timeTick(void)
-{
-#if RKH_CFG_TRC_EN == RKH_ENABLED
-    ++tstamp;
-#endif
-    switch_tick();
-}
-
 RKH_TS_T
 rkh_trc_getts(void)
 {
@@ -397,6 +388,15 @@ rkh_trc_flush( void )
 }
 
 #endif
+
+void
+bsp_timeTick(void)
+{
+#if RKH_CFG_TRC_EN == RKH_ENABLED
+    ++tstamp;
+#endif
+    switch_tick();
+}
 
 
 void


### PR DESCRIPTION
`git submodule add -- /url/of/sub1/repo sub1`
On the other hand, AWS Freertos repo is too big and gets too much time updating when first time download.
This wait would be propagated to RKH repo cloning when synching submodules....
Optionally, only get **freertos/freertos_kernel** repo as submodule may be better.

Adds **BOARD** environment variable definition for **Debug_EDU_CIAA-NXP** and **Debug_CIAA-NXP** builds.
