### PR TITLE
Issue enhance get block from stream

### DIFF
--- a/doc/readme.txt
+++ b/doc/readme.txt
@@ -4361,6 +4361,13 @@ Back: \ref cfg "Configuring framework RKH"
 		<TD> 100 </TD>
 		<TD align="left"> \copybrief RKH_CFG_FWK_TICK_RATE_HZ </TD>
 	</TR>
+	<TR bgColor="#c8cedc" align="center" valign="middle" >
+		<TD align="left"> #RKH_CFG_FWK_AWARE_ISR_PRIO </TD>
+		<TD> integer </TD>
+		<TD> [0..255] </TD>
+		<TD> 0 </TD>
+		<TD align="left"> \copybrief RKH_CFG_FWK_AWARE_ISR_PRIO </TD>
+	</TR>
 </TABLE>
 
 Back: \ref cfg "Configuring framework RKH"

--- a/doc/rkhcfg.h
+++ b/doc/rkhcfg.h
@@ -317,6 +317,22 @@ extern "C" {
  */
 #define RKH_CFG_FWK_TICK_RATE_HZ        100u
 
+/**
+ *  \brief
+ *  This number divides interrupts into "aware" and "unware" interrupts, which 
+ *  are never disabled, and "aware" interrupts, which are disabled in the RKH 
+ *  critical section.
+ *  For example, an interrupt priority number lower than 
+ *  RKH_CFG_FWK_AWARE_ISR_PRIO indicates an "unware" interrupt, whereas an 
+ *  interrupt priority number equal or higher than RKH_CFG_FWK_AWARE_ISR_PRIO 
+ *  indicates an "aware" interrupt.
+ *
+ *  \type       Integer
+ *  \range      [1..255]
+ *  \default    0
+ */
+#define RKH_CFG_FWK_AWARE_ISR_PRIO      0
+
 /** @} doxygen end group definition */
 
 /**

--- a/source/fwk/inc/rkhitl.h
+++ b/source/fwk/inc/rkhitl.h
@@ -1458,6 +1458,15 @@ extern "C" {
 
 #endif
 
+#ifdef RKH_CFG_FWK_AWARE_ISR_PRIO
+#if ((RKH_CFG_FWK_AWARE_ISR_PRIO < 0) || \
+     (RKH_CFG_FWK_AWARE_ISR_PRIO > 255))
+    #error "RKH_CFG_FWK_AWARE_ISR_PRIO       illegally #define'd in 'rkhcfg.h'"
+    #error "                                    [MUST be >= 0]                "
+    #error "                                    [     && <= 255]              "
+#endif
+#endif
+
 /*  PORT          --------------------------------------------------------- */
 #ifndef RKH_CFGPORT_SMA_THREAD_EN
     #error "RKH_CFGPORT_SMA_THREAD_EN            not #define'd in 'rkhport.h'"

--- a/source/fwk/test/support/rkhcfg.h
+++ b/source/fwk/test/support/rkhcfg.h
@@ -229,6 +229,22 @@
 
 #define RKH_CFG_FWK_TICK_RATE_HZ		100u
 
+/**
+ *  \brief
+ *  This number divides interrupts into "aware" and "unware" interrupts, which 
+ *  are never disabled, and "aware" interrupts, which are disabled in the RKH 
+ *  critical section.
+ *  For example, an interrupt priority number lower than 
+ *  RKH_CFG_FWK_AWARE_ISR_PRIO indicates an "unware" interrupt, whereas an 
+ *  interrupt priority number equal or higher than RKH_CFG_FWK_AWARE_ISR_PRIO 
+ *  indicates an "aware" interrupt.
+ *
+ *  \type       Integer
+ *  \range      [1..255]
+ *  \default    0
+ */
+#define RKH_CFG_FWK_AWARE_ISR_PRIO      0
+
 
 /* --- Configuration options related to state machine applications -------- */
 

--- a/source/portable/arm-cortex/rkhs/arm_cm4f/stm32/rkhport.h
+++ b/source/portable/arm-cortex/rkhs/arm_cm4f/stm32/rkhport.h
@@ -63,10 +63,8 @@ extern "C" {
 #endif
 
 /* --------------------------------- Macros -------------------------------- */
-#define LIBRARY_MAX_SYSCALL_IRQ_PRIORITY    5
-
 #define MAX_SYSCALL_IRQ_PRIORITY \
-                   (LIBRARY_MAX_SYSCALL_IRQ_PRIORITY << (8-__NVIC_PRIO_BITS))
+                   (RKH_CFG_FWK_AWARE_ISR_PRIO << (8-__NVIC_PRIO_BITS))
 
 
 #define RKH_CPUSR_TYPE                  uint32_t 

--- a/source/trc/inc/rkhtrc_stream.h
+++ b/source/trc/inc/rkhtrc_stream.h
@@ -134,6 +134,24 @@ void rkh_trc_put(rui8_t b);
 
 /**
  *  \brief
+ *
+ *  Copies the last \a nElem bytes of the stream to \a destBlock.  
+ *	Frequently, this function is used by the called trace analyzer.
+ *
+ *  \param[in] destBlock    pointer to the destination array where the 
+ *                          required stream content is copied.     
+ *  \param[in] nElem        maximum number of bytes to be copied from the 
+ *                          stream.
+ *
+ *  \returns
+ *  Number of bytes copies to \a destBlock. If this number differs from the 
+ *  \a nElem parameter, i.e. it is less than \a nElem, the end-of-stream was 
+ *  reached. If the trace stream is empty, this function returns zero.
+ *
+ *  \note
+ *  The data is stored in a single ring buffer, called trace stream. In this
+ *	manner the recorder always holds the most recent history.
+ *  rkh_trc_getWholeBlock() is NOT protected with a critical section.
  */
 TRCQTY_T rkh_trc_getWholeBlock(rui8_t *destBlock, TRCQTY_T nElem);
 

--- a/source/trc/inc/rkhtrc_stream.h
+++ b/source/trc/inc/rkhtrc_stream.h
@@ -132,6 +132,11 @@ rui8_t *rkh_trc_get_block(TRCQTY_T *nget);
  */
 void rkh_trc_put(rui8_t b);
 
+/**
+ *  \brief
+ */
+TRCQTY_T rkh_trc_getWholeBlock(rui8_t *destBlock, TRCQTY_T nElem);
+
 /* -------------------- External C language linkage end -------------------- */
 #ifdef __cplusplus
 }

--- a/source/trc/src/rkhtrc_stream.c
+++ b/source/trc/src/rkhtrc_stream.c
@@ -49,6 +49,7 @@
 
 /* --------------------------------- Notes --------------------------------- */
 /* ----------------------------- Include files ----------------------------- */
+#include <string.h>
 #include "rkhtrc_stream.h"
 #include "rkhfwk_bittbl.h"
 #include "rkhassert.h"
@@ -154,6 +155,44 @@ rkh_trc_put(rui8_t b)
         trcqty = RKH_CFG_TRC_SIZEOF_STREAM;
         trcout = trcin;
     }
+}
+
+TRCQTY_T 
+rkh_trc_getWholeBlock(rui8_t *destBlock, TRCQTY_T nElem)
+{
+    TRCQTY_T result = 0, nConsumed, n, offset = 0;
+
+    if (trcqty != (TRCQTY_T)0)
+    {
+        nConsumed = (nElem >= trcqty) ? trcqty : nElem;
+        n = (TRCQTY_T)(trcend - trcout); /* Calculates the number of bytes */
+                                         /* to be retrieved */
+        if (n > trcqty)
+        {
+            n = trcqty;
+        }
+        if (n > nElem)
+        {
+            n = nElem;
+        }
+
+        do
+        {
+            memcpy(destBlock + offset, trcout, n);
+            trcout += offset = n;
+            trcqty -= n;
+            result += n;
+            
+            if (trcout >= trcend)
+            {
+                trcout = trcstm;
+            }
+            nConsumed -= n;
+            n = nConsumed;
+        }
+        while (nConsumed);
+    }
+    return result;
 }
 
 /* ------------------------------ End of file ------------------------------ */

--- a/source/trc/test/support/rkhcfg.h
+++ b/source/trc/test/support/rkhcfg.h
@@ -683,7 +683,7 @@
  *	this number, the lower the RAM consumption.
  */
 
-#define RKH_CFG_TRC_SIZEOF_STREAM		512u
+#define RKH_CFG_TRC_SIZEOF_STREAM		32u
 
 
 /* --- Configuration options related to queue (by reference) facility ----- */

--- a/source/trc/test/test_rkhtrc_stream.c
+++ b/source/trc/test/test_rkhtrc_stream.c
@@ -72,7 +72,7 @@ static RKH_SMA_T sender;
 static RKH_EVT_T event;
 static RKH_ST_T state = {{RKH_BASIC, "state"}};
 static RKH_ST_T pseudoState = {{RKH_CHOICE, "pseudoState"}};
-static rui8_t block[RKH_CFG_TRC_SIZEOF_STREAM];
+static rui8_t block[RKH_CFG_TRC_SIZEOF_STREAM + 2];
 
 /* ----------------------- Local function prototypes ----------------------- */
 /* ---------------------------- Local functions ---------------------------- */
@@ -311,19 +311,74 @@ test_GetManyElemsMoreThanStoredUsingWholeBlock(void)
 void
 test_GetManyElemsEqualThanStoredWrapAroundUsingWholeBlock(void)
 {
-    TEST_IGNORE();
+    TRCQTY_T nGetElem;
+    rui8_t i;
+
+    memset(block, 0xaa, 8);
+    rkh_trc_get();
+    for (i = 0; i < ((2 * RKH_CFG_TRC_SIZEOF_STREAM) - 2); ++i)
+    {
+        rkh_trc_put(i);
+    }
+
+    nGetElem = rkh_trc_getWholeBlock(&block[1], 4);
+
+    TEST_ASSERT_EQUAL(4, nGetElem);
+    TEST_ASSERT_EQUAL(0xaa, block[0]);
+    TEST_ASSERT_EQUAL(RKH_CFG_TRC_SIZEOF_STREAM - 2, block[1]);
+    TEST_ASSERT_EQUAL(RKH_CFG_TRC_SIZEOF_STREAM - 1, block[2]);
+    TEST_ASSERT_EQUAL(RKH_CFG_TRC_SIZEOF_STREAM, block[3]);
+    TEST_ASSERT_EQUAL(RKH_CFG_TRC_SIZEOF_STREAM + 1, block[4]);
+    TEST_ASSERT_EQUAL(0xaa, block[5]);
 }
 
 void
 test_GetManyElemsLessThanStoredWrapAroundUsingWholeBlock(void)
 {
-    TEST_IGNORE();
+    TRCQTY_T nGetElem;
+    rui8_t i;
+
+    memset(block, 0xaa, 8);
+    rkh_trc_get();
+    for (i = 0; i < ((2 * RKH_CFG_TRC_SIZEOF_STREAM) - 2); ++i)
+    {
+        rkh_trc_put(i);
+    }
+
+    nGetElem = rkh_trc_getWholeBlock(&block[1], 3);
+
+    TEST_ASSERT_EQUAL(3, nGetElem);
+    TEST_ASSERT_EQUAL(0xaa, block[0]);
+    TEST_ASSERT_EQUAL(RKH_CFG_TRC_SIZEOF_STREAM - 2, block[1]);
+    TEST_ASSERT_EQUAL(RKH_CFG_TRC_SIZEOF_STREAM - 1, block[2]);
+    TEST_ASSERT_EQUAL(RKH_CFG_TRC_SIZEOF_STREAM, block[3]);
+    TEST_ASSERT_EQUAL(0xaa, block[4]);
 }
 
 void
 test_GetManyElemsMoreThanStoredWrapAroundUsingWholeBlock(void)
 {
-    TEST_IGNORE();
+    TRCQTY_T nGetElem;
+    rui8_t i;
+
+    memset(block, 0xaa, RKH_CFG_TRC_SIZEOF_STREAM + 2);
+    rkh_trc_get();
+    for (i = 0; i < ((2 * RKH_CFG_TRC_SIZEOF_STREAM) - 2); ++i)
+    {
+        rkh_trc_put(i);
+    }
+
+    nGetElem = rkh_trc_getWholeBlock(&block[1], RKH_CFG_TRC_SIZEOF_STREAM + 1);
+
+    TEST_ASSERT_EQUAL(0xaa, block[0]);
+    TEST_ASSERT_EQUAL(RKH_CFG_TRC_SIZEOF_STREAM, nGetElem);
+    TEST_ASSERT_EQUAL(RKH_CFG_TRC_SIZEOF_STREAM - 2, block[1]);
+    TEST_ASSERT_EQUAL(RKH_CFG_TRC_SIZEOF_STREAM - 1, block[2]);
+    for (i = 0; i < (RKH_CFG_TRC_SIZEOF_STREAM - 2); ++i)
+    {
+        TEST_ASSERT_EQUAL(RKH_CFG_TRC_SIZEOF_STREAM + i, block[i + 3]);
+    }
+    TEST_ASSERT_EQUAL(0xaa, block[RKH_CFG_TRC_SIZEOF_STREAM + 1]);
 }
 
 /** @} doxygen end group definition */

--- a/source/trc/test/test_rkhtrc_stream.c
+++ b/source/trc/test/test_rkhtrc_stream.c
@@ -55,6 +55,7 @@
 
 /* --------------------------------- Notes --------------------------------- */
 /* ----------------------------- Include files ----------------------------- */
+#include <string.h>
 #include "unity.h"
 #include "rkhtrc_stream.h"
 #include "Mock_rkhsm.h"
@@ -71,6 +72,7 @@ static RKH_SMA_T sender;
 static RKH_EVT_T event;
 static RKH_ST_T state = {{RKH_BASIC, "state"}};
 static RKH_ST_T pseudoState = {{RKH_CHOICE, "pseudoState"}};
+static rui8_t block[RKH_CFG_TRC_SIZEOF_STREAM];
 
 /* ----------------------- Local function prototypes ----------------------- */
 /* ---------------------------- Local functions ---------------------------- */
@@ -238,6 +240,90 @@ test_GetContinuousBlock(void)
 
     for (i = 0; i < nData; i++, output++)
         TEST_ASSERT_EQUAL((rui8_t)i, *output);
+}
+
+void
+test_GetManyFromEmptyUsingWholeBlock(void)
+{
+    TRCQTY_T nGetElem;
+
+    rkh_trc_get();
+    nGetElem = rkh_trc_getWholeBlock(block, 4);
+    TEST_ASSERT_EQUAL(0, nGetElem);
+}
+
+void
+test_GetManyElemsLessThanStoredUsingWholeBlock(void)
+{
+    TRCQTY_T nGetElem;
+
+    memset(block, 0xaa, 8);
+    rkh_trc_put(1);
+    rkh_trc_put(2);
+    rkh_trc_put(3);
+
+    nGetElem = rkh_trc_getWholeBlock(block, 3);
+    TEST_ASSERT_EQUAL(3, nGetElem);
+    TEST_ASSERT_EQUAL(RKH_FLG, block[0]);
+    TEST_ASSERT_EQUAL(1, block[1]);
+    TEST_ASSERT_EQUAL(2, block[2]);
+    TEST_ASSERT_EQUAL(0xaa, block[3]);
+}
+
+void
+test_GetManyElemsEqualThanStoredWholeBlock(void)
+{
+    TRCQTY_T nGetElem;
+
+    memset(block, 0xaa, 8);
+    rkh_trc_put(1);
+    rkh_trc_put(2);
+    rkh_trc_put(3);
+
+    nGetElem = rkh_trc_getWholeBlock(block, 4);
+    TEST_ASSERT_EQUAL(4, nGetElem);
+    TEST_ASSERT_EQUAL(RKH_FLG, block[0]);
+    TEST_ASSERT_EQUAL(1, block[1]);
+    TEST_ASSERT_EQUAL(2, block[2]);
+    TEST_ASSERT_EQUAL(3, block[3]);
+    TEST_ASSERT_EQUAL(0xaa, block[4]);
+}
+
+void
+test_GetManyElemsMoreThanStoredUsingWholeBlock(void)
+{
+    TRCQTY_T nGetElem;
+
+    memset(block, 0xaa, 8);
+    rkh_trc_put(1);
+    rkh_trc_put(2);
+    rkh_trc_put(3);
+
+    nGetElem = rkh_trc_getWholeBlock(block, 5);
+    TEST_ASSERT_EQUAL(4, nGetElem);
+    TEST_ASSERT_EQUAL(RKH_FLG, block[0]);
+    TEST_ASSERT_EQUAL(1, block[1]);
+    TEST_ASSERT_EQUAL(2, block[2]);
+    TEST_ASSERT_EQUAL(3, block[3]);
+    TEST_ASSERT_EQUAL(0xaa, block[4]);
+}
+
+void
+test_GetManyElemsEqualThanStoredWrapAroundUsingWholeBlock(void)
+{
+    TEST_IGNORE();
+}
+
+void
+test_GetManyElemsLessThanStoredWrapAroundUsingWholeBlock(void)
+{
+    TEST_IGNORE();
+}
+
+void
+test_GetManyElemsMoreThanStoredWrapAroundUsingWholeBlock(void)
+{
+    TEST_IGNORE();
 }
 
 /** @} doxygen end group definition */


### PR DESCRIPTION
Added function `rkh_trc_getWholeBlock()` in `rkhtrc_stream.c` module to retrieve the stream content in a more efficient way. This function copies the required bytes from the stream to a destination buffer.

It could be used in `rkh_trc_flush()` function as shown below:
```c
/* ---------------------------- Local variables ---------------------------- */
static rui8_t flushBuff[RKH_CFG_TRC_SIZEOF_STREAM];
...
/* ---------------------------- Global functions --------------------------- */
rkh_trc_flush(void)
{
    TRCQTY_T nBytesReturned;
    RKH_SR_ALLOC();

    RKH_ENTER_CRITICAL_();
    nBytesReturned = rkh_trc_getWholeBlock(flushBuff, RKH_CFG_TRC_SIZEOF_STREAM);
    RKH_EXIT_CRITICAL_();
    if (nBytesReturned != 0)
    {
            /* send retrieved data to something */
    }
}
```
